### PR TITLE
Return a stable object reference from useFormBuilder

### DIFF
--- a/src/formbuilder.tsx
+++ b/src/formbuilder.tsx
@@ -24,7 +24,7 @@ import {
   useForm,
   useWatch,
 } from "react-hook-form";
-import { useMemo } from "react";
+import { useRef } from "react";
 
 /**
  * Represents a field or collection of fields.
@@ -247,12 +247,18 @@ export function useFormBuilder<
   props?: UseFormBuilderProps<TFieldValues, TContext>
 ): UseFormBuilderReturn<TFieldValues, TContext> {
   const methods = useForm<TFieldValues, TContext>(props as never);
-  const fields = useMemo(
-    () => createFormBuilder<TFieldValues>(methods, []),
-    [methods.register, methods.control]
-  );
+  const formBuilderReturnRef = useRef<UseFormBuilderReturn<TFieldValues, TContext> | null>(null);
 
-  return { fields, ...methods };
+  let formBuilderReturn = formBuilderReturnRef.current;
+  if (formBuilderReturn === null) {
+    formBuilderReturn = {
+      fields: createFormBuilder<TFieldValues>(methods, []),
+      ...methods,
+    };
+    formBuilderReturnRef.current = formBuilderReturn;
+  }
+
+  return formBuilderReturn;
 }
 
 // Validate is another source of contravariance.


### PR DESCRIPTION
Currently `useFormBuilder` returns a new object on every render.

This causes effects that directly depend on `builder` (`const builder = useFormBuilder()`) to run after each render.
If you reset form state within this effect, you get an infinite render loop.

The return of `useForm` [should be stable](https://github.com/react-hook-form/react-hook-form/blob/52925875e7a5ab41601e45c3209f6c5bda0099ff/src/useForm.ts#L124), so we can create our own stable reference based on the `useForm` return.