### PR TITLE
Fix formState update regression due to stable return

### DIFF
--- a/src/formbuilder.tsx
+++ b/src/formbuilder.tsx
@@ -253,7 +253,7 @@ export function useFormBuilder<
     [methods.register, methods.control]
   );
 
-  const formBuilderReturnRef = useRef<UseFormBuilderReturn<TFieldValues, TContext>>(methods);
+  const formBuilderReturnRef = useRef<UseFormReturn<TFieldValues, TContext>>(methods);
 
   return Object.assign(formBuilderReturnRef.current, { fields, ...methods });
 }

--- a/src/formbuilder.tsx
+++ b/src/formbuilder.tsx
@@ -24,7 +24,7 @@ import {
   useForm,
   useWatch,
 } from "react-hook-form";
-import { useRef } from "react";
+import { useRef, useMemo } from "react";
 
 /**
  * Represents a field or collection of fields.
@@ -247,8 +247,15 @@ export function useFormBuilder<
   props?: UseFormBuilderProps<TFieldValues, TContext>
 ): UseFormBuilderReturn<TFieldValues, TContext> {
   const methods = useForm<TFieldValues, TContext>(props as never);
+
+  const fields = useMemo(
+    () => createFormBuilder<TFieldValues>(methods, []),
+    [methods.register, methods.control]
+  );
+
   const formBuilderReturnRef = useRef<UseFormBuilderReturn<TFieldValues, TContext>>(methods);
-  return Object.assign(formBuilderReturnRef.current, methods);
+
+  return Object.assign(formBuilderReturnRef.current, { fields, ...methods });
 }
 
 // Validate is another source of contravariance.

--- a/src/formbuilder.tsx
+++ b/src/formbuilder.tsx
@@ -247,18 +247,8 @@ export function useFormBuilder<
   props?: UseFormBuilderProps<TFieldValues, TContext>
 ): UseFormBuilderReturn<TFieldValues, TContext> {
   const methods = useForm<TFieldValues, TContext>(props as never);
-  const formBuilderReturnRef = useRef<UseFormBuilderReturn<TFieldValues, TContext> | null>(null);
-
-  let formBuilderReturn = formBuilderReturnRef.current;
-  if (formBuilderReturn === null) {
-    formBuilderReturn = {
-      fields: createFormBuilder<TFieldValues>(methods, []),
-      ...methods,
-    };
-    formBuilderReturnRef.current = formBuilderReturn;
-  }
-
-  return formBuilderReturn;
+  const formBuilderReturnRef = useRef<UseFormBuilderReturn<TFieldValues, TContext>>(methods);
+  return Object.assign(formBuilderReturnRef.current, methods);
 }
 
 // Validate is another source of contravariance.


### PR DESCRIPTION
My change to the formbuilder return in #1 introduced a bug with consuming `formState`.

Turns out that the `formState` object is actually not stable and my recent change will keep it stale on every subsequent render.

My proposed fix is to still use the initial Object as a stable reference, but copy over all new values before returning it.
This makes it possible to still pass the builder as a stable reference but components can access/subscribe to changes by passing `builder.formState` as dependencies or props.